### PR TITLE
chore: add Netlify deploy preview for PRs

### DIFF
--- a/demo/vite.config.ts
+++ b/demo/vite.config.ts
@@ -5,7 +5,7 @@ import basicSsl from "@vitejs/plugin-basic-ssl";
 import { defineConfig } from "vite";
 
 export default defineConfig({
-	base: "/levita/",
+	base: process.env.VITE_BASE ?? "/levita/",
 	root: ".",
 	resolve: {
 		alias: {

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,7 @@
+[build]
+  command = "pnpm run build && pnpm --filter levita-demo build"
+  publish = "demo/dist"
+
+[build.environment]
+  NODE_VERSION = "22"
+  VITE_BASE = "/"


### PR DESCRIPTION
## Summary

- Add `netlify.toml` to enable automatic deploy previews on pull requests
- Make demo vite base path configurable via `VITE_BASE` env var (defaults to `/levita/` for GitHub Pages)

Production deploy stays on GitHub Pages — Netlify is used for PR previews only.

## Test plan

- [ ] Verify Netlify bot comments a preview URL on this PR
- [ ] Verify GitHub Pages deploy still works (base path `/levita/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)