### PR TITLE
fix(ci): fix release workflow by removing corrupt npm update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,9 +30,6 @@ jobs:
           node-version: 22
           cache: pnpm
 
-      - name: Update npm
-        run: npm install -g npm@latest
-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
The 'Update npm' step was corrupting the runner environment (MODULE_NOT_FOUND). Since we use Node 22 and pnpm, this step is unnecessary.