### PR TITLE
fix(ci): fix NPM OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -46,6 +47,8 @@ jobs:
           commit: "chore: version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ""
+          NPM_CONFIG_PROVENANCE: true
 
       - name: Sync examples to published versions
         if: steps.changesets.outputs.published == 'true'


### PR DESCRIPTION
This PR fixes the NPM OIDC Trusted Publishing integration with Changesets by forcing an empty NPM_TOKEN and explicitly enabling provenance. It also adds a `workflow_dispatch` trigger so the release workflow can be triggered manually to publish pending versions without needing a new commit.