### PR TITLE
fix(ci): definitive fix for NPM Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,11 +49,13 @@ jobs:
         if: steps.changesets.outputs.hasChangesets == 'false'
         run: |
           pnpm build
-          npx changeset publish
+          # Explicitly trigger OIDC handshake by clearing registry token
+          npm config set //registry.npmjs.org/:_authToken ""
+          # Use pnpm recursive publish for native OIDC support
+          pnpm -r publish --access public --no-git-checks --provenance
           echo "published=true" >> $GITHUB_OUTPUT
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_CONFIG_PROVENANCE: true
 
       - name: Sync examples to published versions
         if: steps.publish.outputs.published == 'true'


### PR DESCRIPTION
This PR applies the definitive fix for NPM Trusted Publishing. It explicitly clears the npm registry authToken to force the OIDC handshake and switches to `pnpm -r publish` for a more stable and native publishing experience in a monorepo environment.