### PR TITLE
fix(ci): native pnpm publish for NPM Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,14 +49,14 @@ jobs:
         if: steps.changesets.outputs.hasChangesets == 'false'
         run: |
           pnpm build
-          # Temporarily move .npmrc to avoid interference with OIDC handshake
-          mv .npmrc .npmrc.bak || true
-          npx changeset publish
-          mv .npmrc.bak .npmrc || true
+          # Use native pnpm publish for best OIDC compatibility
+          pnpm -r publish --access public --no-git-checks --provenance
+          # Create and push git tags manually since we bypassed npx changeset publish
+          npx changeset tag
+          git push --tags
           echo "published=true" >> $GITHUB_OUTPUT
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_CONFIG_PROVENANCE: true
 
       - name: Sync examples to published versions
         if: steps.publish.outputs.published == 'true'


### PR DESCRIPTION
This PR switches the release workflow to use native `pnpm -r publish` instead of the Changesets action for the actual publishing step. This is the most reliable way to handle NPM Trusted Publishing (OIDC) in a monorepo while maintaining git tags logic with `npx changeset tag`.