### PR TITLE
fix(ci): final OIDC attempt with uniform URLs and pnpm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,8 +50,7 @@ jobs:
         if: steps.changesets.outputs.hasChangesets == 'false'
         run: |
           pnpm build
-          # Use native pnpm publish which is OIDC-aware
-          # The NODE_AUTH_TOKEN is managed by setup-node via OIDC if NPM_TOKEN is absent
+          # Use native pnpm recursive publish with verified OIDC environment
           pnpm -r publish --access public --no-git-checks --provenance
           # Create and push git tags manually
           npx changeset tag

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -49,7 +49,7 @@
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/Jeromearsene/levita.git",
+		"url": "git+https://github.com/Jeromearsene/levita.git",
 		"directory": "packages/angular"
 	},
 	"homepage": "https://github.com/Jeromearsene/levita#readme"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -46,7 +46,7 @@
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/Jeromearsene/levita.git",
+		"url": "git+https://github.com/Jeromearsene/levita.git",
 		"directory": "packages/core"
 	},
 	"homepage": "https://github.com/Jeromearsene/levita#readme",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -51,7 +51,7 @@
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/Jeromearsene/levita.git",
+		"url": "git+https://github.com/Jeromearsene/levita.git",
 		"directory": "packages/react"
 	},
 	"homepage": "https://github.com/Jeromearsene/levita#readme"

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -46,7 +46,7 @@
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/Jeromearsene/levita.git",
+		"url": "git+https://github.com/Jeromearsene/levita.git",
 		"directory": "packages/svelte"
 	},
 	"homepage": "https://github.com/Jeromearsene/levita#readme"

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -48,7 +48,7 @@
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/Jeromearsene/levita.git",
+		"url": "git+https://github.com/Jeromearsene/levita.git",
 		"directory": "packages/vue"
 	},
 	"homepage": "https://github.com/Jeromearsene/levita#readme"


### PR DESCRIPTION
This PR uniformizes the `repository.url` across all `package.json` files to `git+https://github.com/Jeromearsene/levita.git`. This is a known requirement for strict NPM OIDC validation to avoid 404 errors. It also restores the native `pnpm -r publish` command, which is the most reliable way to handle monorepo publication once the OIDC environment is correctly set up via `setup-node`.