### PR TITLE
fix(ci): fix OIDC 404 via explicit publishConfig registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,11 +50,10 @@ jobs:
         if: steps.changesets.outputs.hasChangesets == 'false'
         run: |
           pnpm build
-          # Native pnpm recursive publish. 
-          # setup-node with registry-url has prepared the .npmrc
-          # pnpm will natively perform the OIDC handshake without manual token variables.
-          pnpm -r publish --access public --no-git-checks --provenance
-          # Create and push git tags manually since we are not using changeset publish
+          # The OIDC environment is ready via setup-node.
+          # All packages now have explicit publishConfig.registry to avoid 404 errors.
+          pnpm -r publish --no-git-checks
+          # Create and push git tags manually
           npx changeset tag
           git push --tags
           echo "published=true" >> $GITHUB_OUTPUT

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -24,6 +24,7 @@
 	],
 	"publishConfig": {
 		"access": "public",
+		"registry": "https://registry.npmjs.org/",
 		"provenance": true
 	},
 	"sideEffects": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,6 +24,7 @@
 	],
 	"publishConfig": {
 		"access": "public",
+		"registry": "https://registry.npmjs.org/",
 		"provenance": true
 	},
 	"sideEffects": [

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -24,6 +24,7 @@
 	],
 	"publishConfig": {
 		"access": "public",
+		"registry": "https://registry.npmjs.org/",
 		"provenance": true
 	},
 	"sideEffects": [

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -24,6 +24,7 @@
 	],
 	"publishConfig": {
 		"access": "public",
+		"registry": "https://registry.npmjs.org/",
 		"provenance": true
 	},
 	"sideEffects": [

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -24,6 +24,7 @@
 	],
 	"publishConfig": {
 		"access": "public",
+		"registry": "https://registry.npmjs.org/",
 		"provenance": true
 	},
 	"sideEffects": [


### PR DESCRIPTION
This PR fixes the 'weird 404' error encountered during OIDC publishing (Strategy C). It uniformizes the `publishConfig` across all packages to include an explicit `registry: https://registry.npmjs.org/`. This ensures that both scoped and non-scoped packages point to the same OIDC-enabled endpoint, which is a known fix for Trusted Publishers in monorepos.