### PR TITLE
fix(ci): unified organization OIDC release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,32 +50,15 @@ jobs:
         if: steps.changesets.outputs.hasChangesets == 'false'
         run: |
           pnpm build
-          # Loop through packages and publish using native npm (standard OIDC flow)
-          # setup-node has prepared the environment.
-          # We use explicit flags instead of publishConfig to avoid known OIDC 404 bugs.
-          for pkg in packages/*; do
-            if [ -d "$pkg" ]; then
-              echo "Processing $pkg..."
-              cd "$pkg"
-              NAME=$(node -p "require('./package.json').name")
-              VERSION=$(node -p "require('./package.json').version")
-              
-              if npm view "$NAME@$VERSION" version > /dev/null 2>&1; then
-                echo "$NAME@$VERSION already published, skipping."
-              else
-                echo "Publishing $NAME@$VERSION via standard NPM OIDC..."
-                npm publish --access public --provenance
-              fi
-              cd -
-            fi
-          done
+          # Now that all packages belong to the same npm organization (levita-js),
+          # native pnpm publish with OIDC will work seamlessly.
+          pnpm -r publish --access public --no-git-checks --provenance
           # Create and push git tags manually
           npx changeset tag
           git push --tags
           echo "published=true" >> $GITHUB_OUTPUT
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: "" # Necessary to trigger handshake when using registry-url
 
       - name: Sync examples to published versions
         if: steps.publish.outputs.published == 'true'


### PR DESCRIPTION
This PR implements the final OIDC release flow. Now that `levita-js` has been transferred to the `levita-js` npm organization, all packages share the same trust entity. This workflow uses native `pnpm -r publish` which is fully OIDC-aware when configured via `actions/setup-node`.