### PR TITLE
fix(ci): final OIDC handshake trigger after trust reset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,7 @@ jobs:
           commit: "chore: version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: "" # Explicitly trigger OIDC handshake by clearing local token expectations
 
       - name: Publish to NPM
         id: publish
@@ -59,6 +60,7 @@ jobs:
           echo "published=true" >> $GITHUB_OUTPUT
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: "" # Explicitly trigger OIDC handshake by clearing local token expectations
 
       - name: Sync examples to published versions
         if: steps.publish.outputs.published == 'true'


### PR DESCRIPTION
This PR adds an explicit `NODE_AUTH_TOKEN: ""` to the publish step. This is a documented trigger for `pnpm` to use the OIDC token provided by `setup-node` instead of looking for a local secret. Combined with the recently recreated Trusted Publisher on npm, this should resolve the remaining 404/auth issues.