### PR TITLE
fix(ci): final unified standard OIDC release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,31 +50,16 @@ jobs:
         if: steps.changesets.outputs.hasChangesets == 'false'
         run: |
           pnpm build
-          # Manual loop using native npm to ensure OIDC handshake is not interrupted by pnpm.
-          # setup-node with registry-url has prepared the system .npmrc for this regsitry.
-          for pkg in packages/*; do
-            if [ -d "$pkg" ]; then
-              echo "Processing $pkg..."
-              cd "$pkg"
-              NAME=$(node -p "require('./package.json').name")
-              VERSION=$(node -p "require('./package.json').version")
-              
-              if npm view "$NAME@$VERSION" version > /dev/null 2>&1; then
-                echo "$NAME@$VERSION already published, skipping."
-              else
-                echo "Publishing $NAME@$VERSION via native NPM OIDC..."
-                npm publish --access public --provenance
-              fi
-              cd -
-            fi
-          done
+          # Now that all packages belong to the same npm organization (levita-js),
+          # and we removed interference from custom auth variables, 
+          # native pnpm publish with OIDC will work seamlessly.
+          pnpm -r publish --access public --no-git-checks --provenance
           # Create and push git tags manually
           npx changeset tag
           git push --tags
           echo "published=true" >> $GITHUB_OUTPUT
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: "" # Signals npm to use the OIDC token from the environment
 
       - name: Sync examples to published versions
         if: steps.publish.outputs.published == 'true'


### PR DESCRIPTION
This PR restores the clean, standard OIDC flow. By removing the `NODE_AUTH_TOKEN: ""` override, we allow `pnpm` to natively use the OIDC token provided by `actions/setup-node`. Combined with the recently completed transfer of `levita-js` to the organization, this is the final intended state for a reliable release.