### PR TITLE
fix(ci): OIDC bridge for pnpm monorepo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,9 +50,9 @@ jobs:
         if: steps.changesets.outputs.hasChangesets == 'false'
         run: |
           pnpm build
-          # Now that all packages belong to the same npm organization (levita-js),
-          # and we removed interference from custom auth variables, 
-          # native pnpm publish with OIDC will work seamlessly.
+          # Inject OIDC auth line into local .npmrc so pnpm actually uses the handshake
+          # This bridges setup-node's config with pnpm's local config priority
+          echo "//registry.npmjs.org/:_authToken=\${NODE_AUTH_TOKEN}" >> .npmrc
           pnpm -r publish --access public --no-git-checks --provenance
           # Create and push git tags manually
           npx changeset tag


### PR DESCRIPTION
This PR fixes the `ENEEDAUTH` error encountered with `pnpm`. By default, `pnpm` ignores the global `.npmrc` prepared by `setup-node` if a local `.npmrc` exists in the project root. This PR explicitly injects the OIDC auth line into the local `.npmrc` just before publishing, ensuring `pnpm` natively triggers the OIDC handshake.