### PR TITLE
fix(ci): reliable release flow via native npm OIDC loop

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,24 +50,30 @@ jobs:
         if: steps.changesets.outputs.hasChangesets == 'false'
         run: |
           pnpm build
-          # OIDC handshake handled by setup-node + registry-url
-          
-          # 1. Publish scoped packages first (using pnpm for workspace awareness)
-          pnpm -r publish --access public --no-git-checks --provenance --filter "@levita-js/*"
-          
-          # 2. Publish unscoped package (levita-js) with explicit isolation
-          # This avoids known 404 bugs when publishing mixed scopes via OIDC
-          cd packages/core
-          npm publish --access public --provenance
-          cd -
-          
+          # Loop through packages and publish using native npm (standard OIDC flow)
+          # Explicit order to handle the main package first.
+          for pkg in packages/core packages/angular packages/react packages/svelte packages/vue; do
+            if [ -d "$pkg" ]; then
+              echo "Processing $pkg..."
+              cd "$pkg"
+              NAME=$(node -p "require('./package.json').name")
+              VERSION=$(node -p "require('./package.json').version")
+              
+              if npm view "$NAME@$VERSION" version > /dev/null 2>&1; then
+                echo "$NAME@$VERSION already published, skipping."
+              else
+                echo "Publishing $NAME@$VERSION via native NPM OIDC..."
+                npm publish --access public --provenance
+              fi
+              cd -
+            fi
+          done
           # Create and push git tags manually since we are not using changeset publish
           npx changeset tag
           git push --tags
           echo "published=true" >> $GITHUB_OUTPUT
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: "" # Explicitly trigger OIDC handshake by clearing local token expectations
 
       - name: Sync examples to published versions
         if: steps.publish.outputs.published == 'true'


### PR DESCRIPTION
This PR implements a robust release strategy by using a manual bash loop with the native `npm publish` command. 

### Why this works:
- **No Interference**: By using `npm` instead of `pnpm` for the final `PUT` request, we bypass `pnpm`'s workspace-aware authentication logic which was conflicting with OIDC.
- **Clean Handshake**: We removed the `NODE_AUTH_TOKEN` variable, allowing `setup-node` to manage the handshake natively.
- **Ordered Publishing**: The loop explicitly starts with `packages/core` (`levita-js`) to ensure the foundation is published first.
- **Trust Re-established**: Combined with the organization transfer and trust reset on npm, this is the most direct path to a successful release.