### PR TITLE
fix(ci): OIDC publish without provenance (attempt)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,36 +50,14 @@ jobs:
         if: steps.changesets.outputs.hasChangesets == 'false'
         run: |
           pnpm build
-          # Loop through packages and publish using native npm (standard OIDC flow)
-          # We use conditional provenance because npm registry rejects it for the unscoped package (levita-js)
-          for pkg in packages/core packages/angular packages/react packages/svelte packages/vue; do
-            if [ -d "$pkg" ]; then
-              echo "Processing $pkg..."
-              cd "$pkg"
-              NAME=$(node -p "require('./package.json').name")
-              VERSION=$(node -p "require('./package.json').version")
-              
-              if npm view "$NAME@$VERSION" version > /dev/null 2>&1; then
-                echo "$NAME@$VERSION already published, skipping."
-              else
-                echo "Publishing $NAME@$VERSION via native NPM OIDC..."
-                if [ "$NAME" = "levita-js" ]; then
-                  # Disable provenance for unscoped package to avoid 404 mapping bug
-                  npm publish --access public
-                else
-                  # Keep provenance for scoped packages (best practice)
-                  npm publish --access public --provenance
-                fi
-              fi
-              cd -
-            fi
-          done
-          # Create and push git tags manually since we are not using changeset publish
+          # Simple OIDC publish without provenance to bypass 404 mapping issues on unscoped packages
+          pnpm -r publish --access public --no-git-checks
           npx changeset tag
           git push --tags
           echo "published=true" >> $GITHUB_OUTPUT
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: "" # Necessary to trigger handshake when using registry-url
 
       - name: Sync examples to published versions
         if: steps.publish.outputs.published == 'true'


### PR DESCRIPTION
This is a diagnostic PR to solve the 404 error on `levita-js`. By removing the `--provenance` flag, we eliminate strict security checks that might be causing the NPM registry to reject the OIDC handshake for unscoped packages in a monorepo.