### PR TITLE
fix(ci): final OIDC attempt with canonical URLs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,26 +50,10 @@ jobs:
         if: steps.changesets.outputs.hasChangesets == 'false'
         run: |
           pnpm build
-          # Loop through packages and publish using native npm (standard OIDC flow)
-          # We use a manual loop to bypass pnpm workspace interference
-          # We omit provenance temporarily to resolve 404 mapping issues on unscoped packages
-          for pkg in packages/core packages/angular packages/react packages/svelte packages/vue; do
-            if [ -d "$pkg" ]; then
-              echo "Processing $pkg..."
-              cd "$pkg"
-              NAME=$(node -p "require('./package.json').name")
-              VERSION=$(node -p "require('./package.json').version")
-              
-              if npm view "$NAME@$VERSION" version > /dev/null 2>&1; then
-                echo "$NAME@$VERSION already published, skipping."
-              else
-                echo "Publishing $NAME@$VERSION via native NPM OIDC (No Provenance)..."
-                # Standard publish to maximize compatibility during initial OIDC transition
-                npm publish --access public
-              fi
-              cd -
-            fi
-          done
+          # Handshake OIDC managed by setup-node + registry-url
+          # Using native pnpm recursive publish with explicit provenance
+          # Repository URLs have been normalized to canonical HTTPS to fix 404 mapping bugs
+          pnpm -r publish --access public --no-git-checks --provenance
           # Create and push git tags manually since we are not using changeset publish
           npx changeset tag
           git push --tags

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -49,7 +49,7 @@
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/Jeromearsene/levita.git",
+		"url": "https://github.com/Jeromearsene/levita",
 		"directory": "packages/angular"
 	},
 	"homepage": "https://github.com/Jeromearsene/levita#readme"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -46,7 +46,7 @@
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/Jeromearsene/levita.git",
+		"url": "https://github.com/Jeromearsene/levita",
 		"directory": "packages/core"
 	},
 	"homepage": "https://github.com/Jeromearsene/levita#readme",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -51,7 +51,7 @@
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/Jeromearsene/levita.git",
+		"url": "https://github.com/Jeromearsene/levita",
 		"directory": "packages/react"
 	},
 	"homepage": "https://github.com/Jeromearsene/levita#readme"

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -46,7 +46,7 @@
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/Jeromearsene/levita.git",
+		"url": "https://github.com/Jeromearsene/levita",
 		"directory": "packages/svelte"
 	},
 	"homepage": "https://github.com/Jeromearsene/levita#readme"

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -48,7 +48,7 @@
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/Jeromearsene/levita.git",
+		"url": "https://github.com/Jeromearsene/levita",
 		"directory": "packages/vue"
 	},
 	"homepage": "https://github.com/Jeromearsene/levita#readme"


### PR DESCRIPTION
This PR uniformizes the `repository.url` across all `package.json` files to the canonical HTTPS format: `https://github.com/Jeromearsene/levita`. 

According to various community resources, NPM Trusted Publishing is extremely sensitive to URL normalization for unscoped packages. This change aims to fix the persistent 404 error on `levita-js`. 

The workflow is also restored to the industry-standard `pnpm -r publish` flow with `--provenance`.